### PR TITLE
feat: do not allow auto unmuting of VPAID during muted ad playback

### DIFF
--- a/src/vast-ima-player.ts
+++ b/src/vast-ima-player.ts
@@ -764,6 +764,8 @@ export class Player extends DelegatedEventTarget {
         if (ad.getAdPodInfo().getAdPosition() > 1) {
           this.#adsManager.setVolume(this.#adsManager.getVolume());
         }
+        // @ts-ignore
+        ad.started = true;
         this.#adElement.classList.remove('nonlinear');
         this._resizeAdsManager();
         // single or non-linear ads
@@ -869,6 +871,10 @@ export class Player extends DelegatedEventTarget {
         break;
       case AdEvent.Type.AD_PROGRESS:
         const adDataProgress = event.getAdData();
+        // when VPAID unmutes itself during already
+        // started ad it does not pause the ad and
+        // continues progress when unmuting requires
+        // user interaction
         if (this.volume > 0
           && this.#adCurrentTime === adDataProgress.currentTime
         ) {
@@ -903,7 +909,8 @@ export class Player extends DelegatedEventTarget {
         const currentVolume = this.#adsManager.getVolume();
         if (currentVolume > 0) {
           this.#lastNonZeroAdVolume = currentVolume;
-          if (!this.#wasExternallyPaused) {
+          // @ts-ignore
+          if (!this.#wasExternallyPaused && this.#currentAd && !this.#currentAd.started) {
             this.#replayUnmutedVpaidTimeoutId = window.setTimeout(() => {
               this._replayUnmutedVpaid();
             }, WAIT_FOR_NO_AD_START_AFTER_UNMUTE);

--- a/src/vast-ima-player.ts
+++ b/src/vast-ima-player.ts
@@ -894,6 +894,11 @@ export class Player extends DelegatedEventTarget {
           this._playContent();
         }
         break;
+      case AdEvent.Type.PAUSED:
+        // just in case IMA will properly trigger pause
+        // when unmute was not successful during VPAID ad
+        window.clearTimeout(this.#replayUnmutedVpaidTimeoutId);
+        break;
       case AdEvent.Type.VOLUME_CHANGED:
         const currentVolume = this.#adsManager.getVolume();
         if (currentVolume > 0) {


### PR DESCRIPTION
Google IMA does not trigger "PAUSED" when a VPAID ad gets unmuted
during muted ad playback. It also can happen that VPAID ad does not start
ad playback at all when ad gets unmuted before start. These hacks fixes
that behaviour.